### PR TITLE
Prevent Location Services Dialog Box  from closing on outside touch and back button event

### DIFF
--- a/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
+++ b/android/src/main/java/com/showlocationservicesdialogbox/LocationServicesDialogBoxModule.java
@@ -99,6 +99,12 @@ class LocationServicesDialogBoxModule extends ReactContextBaseJavaModule impleme
                         });
 
         alertDialog = builder.create();
+        if (!map.hasKey("preventOutSideTouch") || !map.getBoolean("preventOutSideTouch")){        
+        alertDialog.setCanceledOnTouchOutside(false);
+        }
+        if (!map.hasKey("preventBackClick") || !map.getBoolean("preventBackClick")){
+        alertDialog.setCancelable(false);
+        }
         alertDialog.show();
     }
 


### PR DESCRIPTION

add two optional parameters 
            preventOutSideTouch: false,  //true=>Outside click and back click the location service pop up close.
            preventBackClick: false     //true=>back click the location service pop up close.
     